### PR TITLE
Fix/patch agenttoken (#38)

### DIFF
--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -59,6 +59,11 @@
       "address": "0xBF6fcd76292D23d89949b5e6616ba2571eA5370c",
       "txHash": "0x613bebbb5f6ee2210ff8427420da74cda2ff442107e485b6ab9ee42c0d3968ef",
       "kind": "transparent"
+    },
+    {
+      "address": "0x9883A9f1284A1F0187401195DC1309F6cC167147",
+      "txHash": "0xe43bf7a7671f70429f5fb110f990bf1ba5dedf5c4f8e15efeb708a67ea24fd03",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -6733,6 +6738,522 @@
               "slot": "0"
             }
           ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0x8C2d2906De2d92548A8BD8F21d34318d74fc1cB0"
+      ]
+    },
+    "195062b8109a32e246f9e4beeacbc1886636eeaefdbb941998a042ee4ccab7d2": {
+      "address": "0x192Df953b317B8aAEc96CE48BAAcE2c4087f573f",
+      "layout": {
+        "solcVersion": "0.8.20",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactory)4780",
+            "contract": "FRouter",
+            "src": "contracts/fun/FRouter.sol:24"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouter",
+            "src": "contracts/fun/FRouter.sol:25"
+          },
+          {
+            "label": "taxManager",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "FRouter",
+            "src": "contracts/fun/FRouter.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)25_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)219_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)25_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactory)4780": {
+            "label": "contract FFactory",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "ce9a160ef088923c0f24db11c291ed71c15a77dc04974a9fec3e7648efd919e7": {
+      "address": "0x192Df953b317B8aAEc96CE48BAAcE2c4087f573f",
+      "layout": {
+        "solcVersion": "0.8.20",
+        "storage": [
+          {
+            "label": "factory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FFactory)4780",
+            "contract": "FRouter",
+            "src": "contracts/fun/FRouter.sol:23"
+          },
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "FRouter",
+            "src": "contracts/fun/FRouter.sol:24"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)25_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)219_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)25_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(FFactory)4780": {
+            "label": "contract FFactory",
+            "numberOfBytes": "20"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "2531eed915c4626dca0e7bdf6fc9e2ce1e9a3ccd4bb883a22da34cd6bfe15d30": {
+      "address": "0x8534ED9Dcd2E3B407F6B8CDDc60f4860C425e7a5",
+      "txHash": "0xec3717bea0be52af882501f58e5bce85055afd2d7e429328537c10f7a890bd06",
+      "layout": {
+        "solcVersion": "0.8.20",
+        "storage": [
+          {
+            "label": "assetToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:21"
+          },
+          {
+            "label": "taxToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:22"
+          },
+          {
+            "label": "router",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_contract(IRouter)2539",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:23"
+          },
+          {
+            "label": "bondingRouter",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:24"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:25"
+          },
+          {
+            "label": "minSwapThreshold",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:26"
+          },
+          {
+            "label": "maxSwapThreshold",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint256",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:27"
+          },
+          {
+            "label": "_slippage",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_uint16",
+            "contract": "BondingTax",
+            "src": "contracts/tax/BondingTax.sol:28"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)25_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)93_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)25_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IRouter)2539": {
+            "label": "contract IRouter",
+            "numberOfBytes": "20"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
           "erc7201:openzeppelin.storage.AccessControl": [
             {
               "contract": "AccessControlUpgradeable",

--- a/contracts/tax/AgentTax.sol
+++ b/contracts/tax/AgentTax.sol
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "../pool/IRouter.sol";
+import "../virtualPersona/IAgentNft.sol";
+
+contract AgentTax is Initializable, AccessControlUpgradeable {
+    using SafeERC20 for IERC20;
+    struct TaxHistory {
+        uint256 agentId;
+        uint256 amount;
+    }
+
+    struct TaxAmounts {
+        uint256 amountCollected;
+        uint256 amountSwapped;
+    }
+
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+    uint256 internal constant DENOM = 10000;
+
+    address public assetToken;
+    address public taxToken;
+    IRouter public router;
+    address public treasury;
+    uint16 public feeRate;
+    uint256 public minSwapThreshold;
+    uint256 public maxSwapThreshold;
+    IAgentNft public agentNft;
+
+    event SwapParamsUpdated(
+        address oldRouter,
+        address newRouter,
+        address oldAsset,
+        address newAsset,
+        uint16 oldFeeRate,
+        uint16 newFeeRate
+    );
+    event SwapThresholdUpdated(
+        uint256 oldMinThreshold,
+        uint256 newMinThreshold,
+        uint256 oldMaxThreshold,
+        uint256 newMaxThreshold
+    );
+    event TreasuryUpdated(address oldTreasury, address newTreasury);
+    event SwapExecuted(
+        uint256 indexed agentId,
+        uint256 taxTokenAmount,
+        uint256 assetTokenAmount
+    );
+    event SwapFailed(uint256 indexed agentId, uint256 taxTokenAmount);
+    event TaxCollected(bytes32 indexed txhash, uint256 agentId, uint256 amount);
+
+    mapping(uint256 agentId => address tba) private _agentTba; // cache to prevent calling AgentNft frequently
+    mapping(bytes32 txhash => TaxHistory history) public taxHistory;
+    mapping(uint256 agentId => TaxAmounts amounts) public agentTaxAmounts;
+
+    error TxHashExists(bytes32 txhash);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address defaultAdmin_,
+        address assetToken_,
+        address taxToken_,
+        address router_,
+        address treasury_,
+        uint256 minSwapThreshold_,
+        uint256 maxSwapThreshold_,
+        address nft_
+    ) external initializer {
+        __AccessControl_init();
+
+        _grantRole(ADMIN_ROLE, defaultAdmin_);
+        _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin_);
+        assetToken = assetToken_;
+        taxToken = taxToken_;
+        router = IRouter(router_);
+        treasury = treasury_;
+        minSwapThreshold = minSwapThreshold_;
+        maxSwapThreshold = maxSwapThreshold_;
+        IERC20(taxToken).forceApprove(router_, type(uint256).max);
+        agentNft = IAgentNft(nft_);
+
+        feeRate = 100;
+    }
+
+    function updateSwapParams(
+        address router_,
+        address assetToken_,
+        uint16 feeRate_
+    ) public onlyRole(ADMIN_ROLE) {
+        address oldRouter = address(router);
+        address oldAsset = assetToken;
+        uint16 oldFee = feeRate;
+
+        assetToken = assetToken_;
+        router = IRouter(router_);
+        feeRate = feeRate_;
+
+        IERC20(taxToken).forceApprove(router_, type(uint256).max);
+        IERC20(taxToken).forceApprove(oldRouter, 0);
+
+        emit SwapParamsUpdated(
+            oldRouter,
+            router_,
+            oldAsset,
+            assetToken_,
+            oldFee,
+            feeRate_
+        );
+    }
+
+    function updateSwapThresholds(
+        uint256 minSwapThreshold_,
+        uint256 maxSwapThreshold_
+    ) public onlyRole(ADMIN_ROLE) {
+        uint256 oldMin = minSwapThreshold;
+        uint256 oldMax = maxSwapThreshold;
+
+        minSwapThreshold = minSwapThreshold_;
+        maxSwapThreshold = maxSwapThreshold_;
+
+        emit SwapThresholdUpdated(
+            oldMin,
+            minSwapThreshold_,
+            oldMax,
+            maxSwapThreshold_
+        );
+    }
+
+    function updateTreasury(address treasury_) public onlyRole(ADMIN_ROLE) {
+        address oldTreasury = treasury;
+        treasury = treasury_;
+
+        emit TreasuryUpdated(oldTreasury, treasury_);
+    }
+
+    function withdraw(address token) external onlyRole(ADMIN_ROLE) {
+        IERC20(token).safeTransfer(
+            treasury,
+            IERC20(token).balanceOf(address(this))
+        );
+    }
+
+    function handleAgentTaxes(
+        uint256 agentId,
+        bytes32[] memory txhashes,
+        uint256[] memory amounts,
+        uint256 minOutput
+    ) public onlyRole(EXECUTOR_ROLE) {
+        require(txhashes.length == amounts.length, "Unmatched inputs");
+        TaxAmounts storage agentAmounts = agentTaxAmounts[agentId];
+        uint256 totalAmount = 0;
+        for (uint i = 0; i < txhashes.length; i++) {
+            bytes32 txhash = txhashes[i];
+            if (taxHistory[txhash].agentId > 0) {
+                revert TxHashExists(txhash);
+            }
+            taxHistory[txhash] = TaxHistory(agentId, amounts[i]);
+            totalAmount += amounts[i];
+            emit TaxCollected(txhash, agentId, amounts[i]);
+        }
+        agentAmounts.amountCollected += totalAmount;
+        _swapForAsset(agentId, minOutput);
+    }
+
+    function _getTba(uint256 agentId) internal returns (address) {
+        address tba = _agentTba[agentId];
+        if (tba == address(0)) {
+            tba = agentNft.virtualInfo(agentId).tba;
+            _agentTba[agentId] = tba;
+        }
+        return tba;
+    }
+
+    function swapForAsset(
+        uint256 agentId,
+        uint256 minOutput
+    ) public onlyRole(EXECUTOR_ROLE) returns (bool, uint256) {
+        return _swapForAsset(agentId, minOutput);
+    }
+
+    function _swapForAsset(
+        uint256 agentId,
+        uint256 minOutput
+    ) internal returns (bool, uint256) {
+        TaxAmounts storage agentAmounts = agentTaxAmounts[agentId];
+        uint256 amountToSwap = agentAmounts.amountCollected -
+            agentAmounts.amountSwapped;
+
+        uint256 balance = IERC20(taxToken).balanceOf(address(this));
+
+        require(balance >= amountToSwap, "Insufficient balance");
+
+        address tba = _getTba(agentId);
+        require(tba != address(0), "Agent does not have TBA");
+
+        if (amountToSwap < minSwapThreshold) {
+            return (false, 0);
+        }
+
+        if (amountToSwap > maxSwapThreshold) {
+            amountToSwap = maxSwapThreshold;
+        }
+
+        address[] memory path = new address[](2);
+        path[0] = taxToken;
+        path[1] = assetToken;
+
+        uint256[] memory amountsOut = router.getAmountsOut(amountToSwap, path);
+        require(amountsOut.length > 1, "Failed to fetch token price");
+
+        try
+            router.swapExactTokensForTokens(
+                amountToSwap,
+                minOutput,
+                path,
+                address(this),
+                block.timestamp + 300
+            )
+        returns (uint256[] memory amounts) {
+            uint256 assetReceived = amounts[1];
+            emit SwapExecuted(agentId, amountToSwap, assetReceived);
+
+            uint256 feeAmount = (assetReceived * feeRate) / DENOM;
+            IERC20(assetToken).safeTransfer(tba, assetReceived - feeAmount);
+            IERC20(assetToken).safeTransfer(treasury, feeAmount);
+
+            agentAmounts.amountSwapped += amountToSwap;
+
+            return (true, amounts[1]);
+        } catch {
+            emit SwapFailed(agentId, amountToSwap);
+            return (false, 0);
+        }
+    }
+}

--- a/contracts/tax/BondingTax.sol
+++ b/contracts/tax/BondingTax.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -13,20 +12,19 @@ import "../pool/IRouter.sol";
 contract BondingTax is
     Initializable,
     AccessControlUpgradeable,
-    ReentrancyGuardUpgradeable,
     IBondingTax
 {
     using SafeERC20 for IERC20;
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
-    address assetToken;
-    address taxToken;
-    IRouter router;
-    address bondingRouter;
-    address treasury;
-    uint256 minSwapThreshold;
-    uint256 maxSwapThreshold;
+    address public assetToken;
+    address public taxToken;
+    IRouter public router;
+    address public bondingRouter;
+    address public treasury;
+    uint256 public minSwapThreshold;
+    uint256 public maxSwapThreshold;
     uint16 private _slippage;
 
     event SwapParamsUpdated(
@@ -68,7 +66,6 @@ contract BondingTax is
         uint256 maxSwapThreshold_
     ) external initializer {
         __AccessControl_init();
-        __ReentrancyGuard_init();
 
         _grantRole(ADMIN_ROLE, defaultAdmin_);
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin_);
@@ -156,7 +153,7 @@ contract BondingTax is
             amount = maxSwapThreshold;
         }
 
-        address[] memory path;
+        address[] memory path = new address[](2);
         path[0] = taxToken;
         path[1] = assetToken;
 

--- a/contracts/tax/LPRefund.sol
+++ b/contracts/tax/LPRefund.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+contract LPRefund is Initializable, AccessControlUpgradeable {
+    using SafeERC20 for IERC20;
+
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+    address public taxToken;
+
+    event TaxRefunded(
+        bytes32 indexed txhash,
+        address recipient,
+        uint256 amount
+    );
+
+    mapping(bytes32 txhash => uint256 amount) public refunds;
+
+    error TxHashExists(bytes32 txhash);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address defaultAdmin_,
+        address taxToken_
+    ) external initializer {
+        __AccessControl_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin_);
+        _grantRole(ADMIN_ROLE, defaultAdmin_);
+
+        taxToken = taxToken_;
+    }
+
+    function withdraw(address token) external onlyRole(ADMIN_ROLE) {
+        IERC20(token).safeTransfer(
+            _msgSender(),
+            IERC20(token).balanceOf(address(this))
+        );
+    }
+
+    function refund(
+        address recipient,
+        bytes32[] memory txhashes,
+        uint256[] memory amounts
+    ) public onlyRole(EXECUTOR_ROLE) {
+        require(txhashes.length == amounts.length, "Unmatched inputs");
+        uint256 total = 0;
+        for (uint i = 0; i < txhashes.length; i++) {
+            bytes32 txhash = txhashes[i];
+            uint256 amount = amounts[i];
+
+            if (refunds[txhash] > 0) {
+                revert TxHashExists(txhash);
+            }
+            refunds[txhash] = amount;
+            total += amount;
+            emit TaxRefunded(txhash, recipient, amount);
+        }
+
+        IERC20(taxToken).safeTransfer(recipient, total);
+    }
+
+    function manualRefund(
+        bytes32 txhash,
+        address recipient,
+        uint256 amount
+    ) public onlyRole(ADMIN_ROLE) {
+        refunds[txhash] += amount;
+        IERC20(taxToken).safeTransfer(recipient, amount);
+    }
+}

--- a/contracts/virtualPersona/AgentToken.sol
+++ b/contracts/virtualPersona/AgentToken.sol
@@ -62,7 +62,6 @@ contract AgentToken is
     /** @dev {_liquidityPools} Enumerable set for liquidity pool addresses */
     EnumerableSet.AddressSet private _liquidityPools;
 
-
     IAgentFactory private _factory; // Single source of truth
 
     /**
@@ -221,13 +220,19 @@ contract AgentToken is
      * @return uniswapV2Pair_ The pair address
      */
     function _createPair() internal returns (address uniswapV2Pair_) {
-        uniswapV2Pair_ = IUniswapV2Factory(_uniswapRouter.factory()).createPair(
-                address(this),
-                pairToken
-            );
+        uniswapV2Pair_ = IUniswapV2Factory(_uniswapRouter.factory()).getPair(
+            address(this),
+            pairToken
+        );
+
+        if (uniswapV2Pair_ == address(0)) {
+            uniswapV2Pair_ = IUniswapV2Factory(_uniswapRouter.factory())
+                .createPair(address(this), pairToken);
+
+            emit LiquidityPoolCreated(uniswapV2Pair_);
+        }
 
         _liquidityPools.add(uniswapV2Pair_);
-        emit LiquidityPoolCreated(uniswapV2Pair_);
 
         return (uniswapV2Pair_);
     }

--- a/scripts/v2/upgradeFRouter.ts
+++ b/scripts/v2/upgradeFRouter.ts
@@ -1,0 +1,18 @@
+import { ethers, upgrades } from "hardhat";
+
+(async () => {
+  try {
+    const Contract = await ethers.getContractFactory("FRouter")
+    const contract = await ethers.deployContract("FRouter");
+    console.log("Contract deployed to:", contract.target);
+
+    const proxyAdmin = await ethers.getContractAt(
+      "MyProxyAdmin",
+      process.env.FROUTER_PROXY
+    );
+    await proxyAdmin.upgradeAndCall(process.env.FROUTER, contract.target, "0x");
+    console.log("Upgraded FROUTER");
+  } catch (e) {
+    console.log(e);
+  }
+})();


### PR DESCRIPTION
* added bonding tax

* safe swap

* updated swap thresholds, trigger swapForAsset from router

* added aero router

* PVE001-002

* apply slippage control

* only router is allowed to swapForAsset

* added bonding router

* updated slippage data type

* added agent tax contract

* bug fix

* fixed wrong amount

* not using reentrancyguard

* added refund contract

* added script to upgrade frouter

* made variables public

* fixed bondingTax public variables and swap error

* fix swap path

* removed unnecessary import

* updated deployment data

* improved gas efficiency in handleAgentTaxes

* PVE001

* fix denial-of-service bug